### PR TITLE
Allow embedding from simmer.io

### DIFF
--- a/src/util/html.js
+++ b/src/util/html.js
@@ -30,7 +30,7 @@ const BASE_SAFE_HTML_SETTINGS = {
     },
     allowedIframeHostnames: [
         "www.youtube.com", "www.youtube-nocookie.com", "player.vimeo.com", "www.facebook.com", "peer.tube",
-        "rumble.com", "open.spotify.com"
+        "rumble.com", "open.spotify.com", "c.simmer.io" 
     ],
     allowedIframeDomains: ["livejournal.com"],
     allowedStyles: {

--- a/src/util/html.js
+++ b/src/util/html.js
@@ -18,7 +18,7 @@ const BASE_SAFE_HTML_SETTINGS = {
         p: ["style"],
         iframe: [
             "src", "width", "height", "frameborder", "allow", "allowfullscreen", "sandbox", "scrolling",
-            "allowtransparency"
+            "allowtransparency", "style"
         ],
         "mr-spoiler": ["title"]
     },
@@ -39,6 +39,10 @@ const BASE_SAFE_HTML_SETTINGS = {
         },
         b: {
             "background-image": [/^url\('https:\/\/twemoji.maxcdn.com\//]
+        },
+        "iframe": {
+            "width": [/^\d+px$/],
+            "height": [/^\d+px$/]
         }
     },
     transformTags: {


### PR DESCRIPTION
This is webgl games hosting. I saw somebody requesting it in the comments :)

Example embed code:
```html
<iframe src="https://c.simmer.io/static/unityFrame/index.html?url=https%3A%2F%2Fsimmercdn.com%2Funity%2FArOcg0jhIjQgaW2bkAbPZlOkgc83%2Fcontent%2F60cfc1db-8a32-6180-7f42-19302166284e&imagePath=screens/0.png" style="width:480px;height:300px;border:0"></iframe>
```