### PR TITLE
Adding clarifying comment to replied-to-previous icon

### DIFF
--- a/src/ui/comment/CommentRepliedTo.js
+++ b/src/ui/comment/CommentRepliedTo.js
@@ -11,7 +11,7 @@ const CommentRepliedTo = ({comment, postingId, previousId}) => {
         return null;
     }
     if (comment.repliedTo.id === previousId) {
-        return <div className="replied-to-previous"><FontAwesomeIcon icon="reply"/></div>;
+        return <div className="replied-to-previous" title="Reply to previous comment"><FontAwesomeIcon icon="reply"/></div>;
     }
     return (
         <RepliedTo postingId={postingId} commentId={comment.repliedTo.id} ownerName={comment.repliedTo.name}


### PR DESCRIPTION
Now on mouse over it will show "Reply to previous comment". I don't know what to do with mouseless (mobile) users