### PR TITLE
Allow "type" attribute in <ol>

### DIFF
--- a/src/util/html.js
+++ b/src/util/html.js
@@ -17,7 +17,7 @@ const BASE_SAFE_HTML_SETTINGS = {
         a: ["href", "title", "data-nodename", "data-href"],
         b: ["style"],
         p: ["style"],
-        ol: ["start"],
+        ol: ["start", "type"],
         iframe: [
             "src", "width", "height", "frameborder", "allow", "allowfullscreen", "sandbox", "scrolling",
             "allowtransparency", "style"


### PR DESCRIPTION
Enables Alpha and Roman enumeration.
```
<ol type="I">
<li>Primus
<li>Secundus
<li>Tertius
</ol>

<ol type="A">
<li>Alpha
<li>Bravo
<li>Charlie
</ol>
```